### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ mpy-cross: $(TARGET_DIR) $(MPY_DIR)/mpy-cross/Makefile
 	@echo Building cross-compiler
 	make -C $(MPY_DIR)/mpy-cross \
 	DEBUG=$(DEBUG) && \
-	cp $(MPY_DIR)/mpy-cross/build/mpy-cross $(TARGET_DIR)
+	cp $(MPY_DIR)/mpy-cross/mpy-cross $(TARGET_DIR)
 
 # disco board with bitcoin library
 disco: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/stm32
@@ -64,7 +64,7 @@ unix: $(TARGET_DIR) mpy-cross $(MPY_DIR)/ports/unix
 	make -C $(MPY_DIR)/ports/unix \
 		USER_C_MODULES=$(USER_C_MODULES) \
 		FROZEN_MANIFEST=$(FROZEN_MANIFEST_UNIX) \
-		CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' && \
+		# CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' && \
 	cp $(MPY_DIR)/ports/unix/build-standard/micropython $(TARGET_DIR)/micropython_unix
 
 simulate: unix


### PR DESCRIPTION
```
➜  specter-diy git:(micropython-upgrade) ✗ make CFLAGS_EXTRA="-Wno-array-bounds -Wno-unused-but-set-variable" unix
Building cross-compiler
make -C f469-disco/micropython/mpy-cross \
        DEBUG=0 && \
        cp f469-disco/micropython/mpy-cross/mpy-cross bin
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Building binary with frozen files
make -C f469-disco/micropython/ports/unix \
                USER_C_MODULES=../../../usermods \
                FROZEN_MANIFEST=../../../../manifests/unix.py \
                # CFLAGS_EXTRA='-DMP_CONFIGFILE="<mpconfigport_specter.h>"' && \
        cp f469-disco/micropython/ports/unix/build-standard/micropython bin/micropython_unix
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
Including User C Module from ../../../usermods/scard
Including User C Module from ../../../usermods/sdram
Including User C Module from ../../../usermods/secp256k1
Including User C Module from ../../../usermods/udisplay_f469
Including User C Module from ../../../usermods/uebmit
Including User C Module from ../../../usermods/uhashlib
GEN build/genhdr/qstr.i.last
In file included from ../../../usermods/udisplay_f469/display_unix.c:5:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/display_unix.c:5:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/display_unix.c:5:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/display_unix.c:5:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/display_unix.c:5:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/display_unix.c:50:
../../../usermods/udisplay_f469/lv_mpy.c:34:10: fatal error: 'lvgl/src/lvgl_private.h' file not found
   34 | #include "lvgl/src/lvgl_private.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
10 errors generated.
In file included from ../../../usermods/udisplay_f469/display_unix_sdl.c:5:
../../../usermods/udisplay_f469/lv_sdl_hal/SDL/modSDL.c:26:10: fatal error: 'SDL2/SDL.h' file not found
   26 | #include <SDL2/SDL.h>
      |          ^~~~~~~~~~~~
1 error generated.
../../../usermods/udisplay_f469/lvgl/src/lv_core/lv_indev.c:24:2: warning: "LV_INDEV_DRAG_THROW must be greater than 0" [-W#warnings]
   24 | #warning "LV_INDEV_DRAG_THROW must be greater than 0"
      |  ^
1 warning generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.c:9:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
1 error generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.c:9:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.c:9:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:34:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/../lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/../lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/../lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
5 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.c:9:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
2 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.c:9:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
1 error generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.c:9:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
3 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_roboto_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_unscii_8.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_unscii_8.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_unscii_8.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_unscii_8.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/lv_font_unscii_8.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/src/lv_font/../../lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_font/../../src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
../../../usermods/udisplay_f469/lvgl/src/lv_draw/lv_img_cache.c:32:2: error: "LV_IMG_CACHE_DEF_SIZE must be >= 1. See lv_conf.h"
   32 | #error "LV_IMG_CACHE_DEF_SIZE must be >= 1. See lv_conf.h"
      |  ^
1 error generated.
In file included from ../../../usermods/udisplay_f469/fonts/square.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/square.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/square.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/square.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/square.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_28.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_22.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_16.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:44:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:26:2: error: "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   26 | #error "lv_list: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_list.h:30:2: error: "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   30 | #error "lv_list: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:54:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_roller.h:26:2: error: "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
   26 | #error "lv_roller: lv_ddlist is required. Enable it in lv_conf.h (LV_USE_DDLIST  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:57:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:26:2: error: "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
   26 | #error "lv_win: lv_btn is required. Enable it in lv_conf.h (LV_USE_BTN  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:34:2: error: "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
   34 | #error "lv_win: lv_img is required. Enable it in lv_conf.h (LV_USE_IMG  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_win.h:38:2: error: "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   38 | #error "lv_win: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:58:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:26:2: error: "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
   26 | #error "lv_tabview: lv_btnm is required. Enable it in lv_conf.h (LV_USE_BTNM  1) "
      |  ^
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_tabview.h:30:2: error: "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
   30 | #error "lv_tabview: lv_page is required. Enable it in lv_conf.h (LV_USE_PAGE  1) "
      |  ^
In file included from ../../../usermods/udisplay_f469/fonts/font_roboto_mono_12.c:1:
In file included from ../../../usermods/udisplay_f469/lvgl/lvgl.h:68:
../../../usermods/udisplay_f469/lvgl/src/lv_objx/lv_spinbox.h:26:2: error: "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
   26 | #error "lv_spinbox: lv_ta is required. Enable it in lv_conf.h (LV_USE_TA  1) "
      |  ^
9 errors generated.
../../../usermods/uhashlib/hashlib.c:24:66: error: too many arguments provided to function-like macro invocation
   24 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA1_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:34:66: error: too many arguments provided to function-like macro invocation
   34 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA1_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:85:66: error: too many arguments provided to function-like macro invocation
   85 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA256_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:95:66: error: too many arguments provided to function-like macro invocation
   95 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA256_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:146:66: error: too many arguments provided to function-like macro invocation
  146 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA512_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:156:66: error: too many arguments provided to function-like macro invocation
  156 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(SHA512_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:207:66: error: too many arguments provided to function-like macro invocation
  207 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(RIPEMD160_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:217:66: error: too many arguments provided to function-like macro invocation
  217 |     mp_obj_hash_t *o = m_new_obj_var(mp_obj_hash_t, state, char, sizeof(RIPEMD160_CTX));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/hashlib.c:363:57: error: too few arguments provided to function-like macro invocation
  363 | MP_REGISTER_MODULE(MP_QSTR_hashlib, hashlib_user_cmodule);
      |                                                         ^
../../py/obj.h:343:9: note: macro 'MP_REGISTER_MODULE' defined here
  343 | #define MP_REGISTER_MODULE(module_name, obj_module, enabled_define)
      |         ^
9 errors generated.
../../../usermods/uhashlib/uhmac.c:50:66: error: too many arguments provided to function-like macro invocation
   50 |     mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, state, char, digestmod+sizeof(size_t));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/uhmac.c:77:66: error: too many arguments provided to function-like macro invocation
   77 |     mp_obj_hmac_t *o = m_new_obj_var(mp_obj_hmac_t, state, char, self->digestmod+sizeof(size_t));
      |                                                                  ^
../../py/misc.h:65:9: note: macro 'm_new_obj_var' defined here
   65 | #define m_new_obj_var(obj_type, var_type, var_num) ((obj_type*)m_malloc(sizeof(obj_type) + sizeof(var_type) * (var_num)))
      |         ^
../../../usermods/uhashlib/uhmac.c:151:51: error: too few arguments provided to function-like macro invocation
  151 | MP_REGISTER_MODULE(MP_QSTR_hmac, hmac_user_cmodule);
      |                                                   ^
../../py/obj.h:343:9: note: macro 'MP_REGISTER_MODULE' defined here
  343 | #define MP_REGISTER_MODULE(module_name, obj_module, enabled_define)
      |         ^
3 errors generated.
make[1]: *** [build/genhdr/qstr.i.last] Error 1
make[1]: *** Deleting file `build/genhdr/qstr.i.last'
make: *** [unix] Error 2
➜  specter-diy git:(micropython-upgrade) ✗
```